### PR TITLE
Refactor how worldstate data is cached

### DIFF
--- a/controllers/worldstate.js
+++ b/controllers/worldstate.js
@@ -9,9 +9,9 @@ const {
 } = require('../lib/utilities');
 
 const get = async (platform, language) => {
-  const ws = await worldStates[platform][language].getData();
+  const ws = worldStates[platform][language];
   ws.twitter = await twitter.getData(); // inject twitter data
-  return ws;
+  return ws.data;
 };
 
 const router = express.Router();
@@ -40,8 +40,7 @@ router.use((req, res, next) => {
 
 router.get('/', cache('1 minute'), ah(async (req, res) => {
   logger.silly(`Got ${req.originalUrl}`);
-  const ws = await worldStates[req.platform][req.language].getData();
-  ws.twitter = await twitter.getData();
+  const ws = await get(req.platform, req.language);
   res.setHeader('Content-Language', req.language);
   setHeadersAndJson(res, ws);
 }));

--- a/lib/caches/WSCache.js
+++ b/lib/caches/WSCache.js
@@ -21,7 +21,7 @@ class WSCache extends EventEmitter {
   }
 
   set data(newData) {
-    const t =  new Worldstate(newData, { locale: this.language, kuvaCache: this.kuvaCache });
+    const t = new Worldstate(newData, { locale: this.language, kuvaCache: this.kuvaCache });
     if (!t.timestamp) return;
     this.inner = t;
     this.emit('update', newData);

--- a/lib/caches/WSCache.js
+++ b/lib/caches/WSCache.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const Worldstate = require('warframe-worldstate-parser');
+const EventEmitter = require('events');
+
+class WSCache extends EventEmitter {
+  constructor(platform, language, kuvaCache) {
+    super();
+    this.inner = null;
+    Object.defineProperty(this, 'inner', { enumerable: false, configurable: false });
+
+    this.kuvaCache = kuvaCache;
+    Object.defineProperty(this, 'kuvaCache', { enumerable: false, configurable: false });
+
+    this.platform = platform;
+    this.language = language;
+  }
+
+  get data() {
+    return this.inner;
+  }
+
+  set data(newData) {
+    const t =  new Worldstate(newData, { locale: this.language, kuvaCache: this.kuvaCache });
+    if (!t.timestamp) return;
+    this.inner = t;
+    this.emit('update', newData);
+  }
+
+  set twitter(newTwitter) {
+    if (!(newTwitter && newTwitter.length)) return;
+    this.inner.twitter = newTwitter;
+  }
+}
+
+module.exports = WSCache;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -84,13 +84,6 @@ platforms.forEach((p) => {
       worldStates[p][locale].data = dataStr;
     });
   });
-
-  // warframeData.locales.forEach((locale) => {
-  //   worldStates[p][locale] = new Cache(url, wsTimeout, {
-  //     parser, logger, delayStart: !(p === 'pc' && locale === 'en'), ,
-  //     integrity: (data) => data.timestamp && new Date(data.timestamp).getTime() > 0,
-  //   });
-  // });
 });
 
 const titleCase = str => str.toLowerCase().replace(/\b\w/g, l => l.toUpperCase());

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -112,5 +112,4 @@ module.exports = {
   socketLogger,
   groupBy,
   languages: warframeData.locales,
-  wsRawCaches,
 };

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -3,12 +3,12 @@
 const ah = require('express-async-handler');
 const warframeData = require('warframe-worldstate-data');
 const Items = require('warframe-items');
-const WSCache = require('./caches/WSCache');
 
 const { transports, createLogger, format } = require('winston');
 const apiCache = require('apicache');
 
 const Cache = require('json-fetch-cache');
+const WSCache = require('./caches/WSCache');
 
 const platforms = ['pc', 'ps4', 'xb1', 'swi'];
 const platformAliases = ['ns'];
@@ -78,7 +78,11 @@ platforms.forEach((p) => {
   warframeData.locales.forEach((locale) => {
     worldStates[p][locale] = new WSCache(p, locale, kuvaCache);
   });
-  wsRawCaches[p] = new Cache(url, wsTimeout, { delayStart: false, parser: (str) => str, useEmitter: true });
+  wsRawCaches[p] = new Cache(url, wsTimeout, {
+    delayStart: false,
+    parser: str => str,
+    useEmitter: true,
+  });
   wsRawCaches[p].on('update', (dataStr) => {
     warframeData.locales.forEach((locale) => {
       worldStates[p][locale].data = dataStr;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -3,7 +3,7 @@
 const ah = require('express-async-handler');
 const warframeData = require('warframe-worldstate-data');
 const Items = require('warframe-items');
-const Worldstate = require('warframe-worldstate-parser');
+const WSCache = require('./caches/WSCache');
 
 const { transports, createLogger, format } = require('winston');
 const apiCache = require('apicache');
@@ -37,7 +37,6 @@ const groupBy = (array, field) => {
   return grouped;
 };
 
-
 /* Logger setup */
 const transport = new transports.Console({ colorize: true });
 const logFormat = printf(info => `[${info.label}] ${info.level}: ${info.message}`);
@@ -65,24 +64,33 @@ socketLogger.level = process.env.LOG_LEVEL || 'info';
 delete warframeData.weapons;
 delete warframeData.warframes;
 
-const parser = function parser(data, opts) {
-  return new Worldstate(data, opts);
-};
-
 const kuvaCache = new Cache('https://10o.io/kuvalog.json', 300000, {
   useEmitter: false, logger, delayStart: false, maxRetry: 1,
 });
 
 const wsTimeout = process.env.CACHE_TIMEOUT || 60000;
+const wsRawCaches = {};
 
 platforms.forEach((p) => {
   const url = `http://content${p === 'pc' ? '' : `.${p}`}.warframe.com/dynamic/worldState.php`;
   worldStates[p] = {};
+
   warframeData.locales.forEach((locale) => {
-    worldStates[p][locale] = new Cache(url, wsTimeout, {
-      parser, logger, delayStart: !(p === 'pc' && locale === 'en'), opts: { locale, kuvaCache },
+    worldStates[p][locale] = new WSCache(p, locale, kuvaCache);
+  });
+  wsRawCaches[p] = new Cache(url, wsTimeout, { delayStart: false, parser: (str) => str, useEmitter: true });
+  wsRawCaches[p].on('update', (dataStr) => {
+    warframeData.locales.forEach((locale) => {
+      worldStates[p][locale].data = dataStr;
     });
   });
+
+  // warframeData.locales.forEach((locale) => {
+  //   worldStates[p][locale] = new Cache(url, wsTimeout, {
+  //     parser, logger, delayStart: !(p === 'pc' && locale === 'en'), ,
+  //     integrity: (data) => data.timestamp && new Date(data.timestamp).getTime() > 0,
+  //   });
+  // });
 });
 
 const titleCase = str => str.toLowerCase().replace(/\b\w/g, l => l.toUpperCase());
@@ -111,4 +119,5 @@ module.exports = {
   socketLogger,
   groupBy,
   languages: warframeData.locales,
+  wsRawCaches,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -356,9 +356,9 @@
       }
     },
     "apicache": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/apicache/-/apicache-1.4.0.tgz",
-      "integrity": "sha512-pX/Sf9q9HNzAC5F+hPgxt8v3eQVZkXL/+8HpAnrDJXFmma80F2aHAAeWTql3BsG87lc3T6A7CFPNWMTl97L/7Q=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/apicache/-/apicache-1.5.1.tgz",
+      "integrity": "sha512-a8ogfJyBBHWYl6cB8K3R2K704zngVQfBfe7vFSRmkzskwqVft3h2ziCSX0t8prpm3Dk7LqbqxsmLfUYiC8OjJA=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -3478,9 +3478,9 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-fetch-cache": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/json-fetch-cache/-/json-fetch-cache-1.1.0.tgz",
-      "integrity": "sha512-tzgUpQoSwDEgS0vRoC8Zi3fmv41dmQlTCX2qTcpLQRYOkW9zpa/Mjw4Bjzeota/cJgcZXJxKnyGXyCjc1g4Jfg=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/json-fetch-cache/-/json-fetch-cache-1.2.0.tgz",
+      "integrity": "sha512-V/FEHZZBfV95hNr3q3qO2SL5sULycXfvCJNFsDiSVHSkYJkF8cdLHT2XLnFXREanvH5SzShXHPNLDwW3n4SH6g=="
     },
     "json-query": {
       "version": "2.2.2",
@@ -5693,9 +5693,9 @@
       }
     },
     "warframe-items": {
-      "version": "1.486.0",
-      "resolved": "https://registry.npmjs.org/warframe-items/-/warframe-items-1.486.0.tgz",
-      "integrity": "sha512-b2GRX625wv1n0CKV3hm9tARBv8OOvejiOybXtGj1aFGja8bjwfQEaJAWX3d15DoMr8iZmQBVludNs8F+xN+cYA=="
+      "version": "1.489.0",
+      "resolved": "https://registry.npmjs.org/warframe-items/-/warframe-items-1.489.0.tgz",
+      "integrity": "sha512-sSh3cdblkWWaheG0n4i+xLu897S04dlohw4NOihx/ad948aETSZUt/kXOKooTnXldn0W9ntxGOezzM+8GShLmg=="
     },
     "warframe-nexus-query": {
       "version": "1.6.5",
@@ -5726,9 +5726,9 @@
       "integrity": "sha512-vgMY8Khz8mZ51dx7IbpvMndfVe5WWRYLMwJHMyNuOa5EqkIAoWA6ll/GBqY60fwrAhx3Gvc67iyNzp8uYpGC6Q=="
     },
     "warframe-worldstate-parser": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/warframe-worldstate-parser/-/warframe-worldstate-parser-2.8.6.tgz",
-      "integrity": "sha512-ddDmdohMnE0vgEIk8mGNu+cfbyEgojUJKYYL9GFYZ6GymcBXUvL0h/cYUBUXPlKEnychwufvJxwZPj0cuBeEuA==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/warframe-worldstate-parser/-/warframe-worldstate-parser-2.9.2.tgz",
+      "integrity": "sha512-p4rZoW/yeb3reNRgoaeGdMYmOR/UtKPfAfCNnq5DAaughrF0nGA2I3she2nBH6EWaZ9WR1Z0aTKEVAcZ+cQ5uA==",
       "requires": {
         "json-fetch-cache": "^1.1.0",
         "node-fetch": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -5,19 +5,19 @@
   "repository": "https://github.com/wfcd/warframe-status.git",
   "dependencies": {
     "@sentry/node": "^5.6.1",
-    "apicache": "^1.4.0",
+    "apicache": "^1.5.1",
     "express": "^4.17.1",
     "express-async-handler": "^1.1.3",
     "helmet": "^3.20.0",
-    "json-fetch-cache": "^1.1.0",
+    "json-fetch-cache": "^1.2.0",
     "nexushub-client": "^1.2.0",
     "rss-feed-emitter": "^2.0.1",
     "socket.io": "^2.2.0",
     "twitter": "^1.7.1",
-    "warframe-items": "^1.486.0",
+    "warframe-items": "^1.489.0",
     "warframe-nexus-query": "^1.6.5",
     "warframe-worldstate-data": "^1.0.9",
-    "warframe-worldstate-parser": "^2.8.6",
+    "warframe-worldstate-parser": "^2.9.2",
     "winston": "^3.2.1"
   },
   "devDependencies": {

--- a/sockets/worldstate/index.js
+++ b/sockets/worldstate/index.js
@@ -15,11 +15,13 @@ const worldstate = (socket) => {
     });
   });
 
-  // on initial worldstate request?
-  // can't handle lang yet, but take it anyway
   socket.on('ws-init', async ({ platform, language }) => {
     logger.debug(`socket ${socket.id} sent 'ws-init'`);
-    socket.emit('ws-supply', { platform, language, ws: await worldStates[platform || 'pc'].getData() });
+    socket.emit('ws-supply', {
+      platform,
+      language,
+      ws: await worldStates[platform || 'pc'][language || 'en'].data,
+    });
   });
 };
 


### PR DESCRIPTION
chore: refactor to only request 1 of any platform, use smoother caching to leverage better emitters

- fetch just the string content of the unparsed ws
- cache the parsed data publically, but parse after requested, don't request one-by-one
- maintain socket-ability
- leverage some es6 awesomeness for emitting data when new data is set on the inner worldstate cache
