### PR TITLE
fix: item inclusion in single item search

### DIFF
--- a/src/controllers/wfItems.js
+++ b/src/controllers/wfItems.js
@@ -129,6 +129,7 @@ router.get('/:item', cache('10 hours'), (req, res) => {
   logger.silly(`Got ${req.originalUrl}`);
   const { remove, only } = req.query;
   let result;
+  let keyDistance;
   let exact = false;
   const by = req.query.by || 'name';
 
@@ -137,8 +138,13 @@ router.get('/:item', cache('10 hours'), (req, res) => {
       result = item;
       exact = true;
     }
+
     if (item[by].toLowerCase().includes(req.params.item.toLowerCase()) && !exact) {
-      result = item;
+      const distance = item[by].toLowerCase().replace(req.params.item.toLowerCase(), '').length;
+      if (!keyDistance || distance < keyDistance) {
+        keyDistance = distance;
+        result = item;
+      }
     }
   });
 


### PR DESCRIPTION
### What did you fix? (provide a description or issue closes statement)
closes #377 

---

### Reproduction steps
1. Get https://api.warframestat.us/items/excalibur%20umbr?only=name
---

### Evidence/screenshot/link to line

You can see my fix [in these lines](https://github.com/WFCD/warframe-status/blob/fix-item-inclusion/src/controllers/wfItems.js#L132-L148)

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Enhancement]**
