### PR TITLE
fix(deps): Bump warframe-worldstate-parser from 2.23.2 to 2.24.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "warframe-items": "^1.1253.1229",
         "warframe-nexus-query": "^1.6.16",
         "warframe-worldstate-data": "^1.23.8",
-        "warframe-worldstate-parser": "^2.23.2",
+        "warframe-worldstate-parser": "^2.24.0",
         "winston": "^3.7.2",
         "worldstate-emitter": "^1.0.8",
         "ws": "^7.5.8"
@@ -8985,9 +8985,9 @@
       }
     },
     "node_modules/warframe-worldstate-parser": {
-      "version": "2.23.2",
-      "resolved": "https://registry.npmjs.org/warframe-worldstate-parser/-/warframe-worldstate-parser-2.23.2.tgz",
-      "integrity": "sha512-Wgy9IxwuB3+kzNNq8bWodz+wPlzZfqm8YhYAQeJ9gQjWqG8+a0lFShtg3xoJea5VYa08bSEllJBWf5e+826myg==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/warframe-worldstate-parser/-/warframe-worldstate-parser-2.24.0.tgz",
+      "integrity": "sha512-XjH7B5Tf1PTPO3Zq2xxxJcd13WzvxlHbZXNRBS7ds//AeemzlBhxIYQBkGt5zCKRnL27nnuxLKqpABuWiIZlZA==",
       "dependencies": {
         "node-fetch": "^2.6.1"
       },
@@ -16175,9 +16175,9 @@
       "integrity": "sha512-Vo+yggT1YO9d9ibFHwcIqcGhcAUs990JMr64M8O8uVCABlsQnyk7zdGq00oSDsTI+sDXpdcPr/OVT6bfYQdayQ=="
     },
     "warframe-worldstate-parser": {
-      "version": "2.23.2",
-      "resolved": "https://registry.npmjs.org/warframe-worldstate-parser/-/warframe-worldstate-parser-2.23.2.tgz",
-      "integrity": "sha512-Wgy9IxwuB3+kzNNq8bWodz+wPlzZfqm8YhYAQeJ9gQjWqG8+a0lFShtg3xoJea5VYa08bSEllJBWf5e+826myg==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/warframe-worldstate-parser/-/warframe-worldstate-parser-2.24.0.tgz",
+      "integrity": "sha512-XjH7B5Tf1PTPO3Zq2xxxJcd13WzvxlHbZXNRBS7ds//AeemzlBhxIYQBkGt5zCKRnL27nnuxLKqpABuWiIZlZA==",
       "requires": {
         "node-fetch": "^2.6.1"
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "warframe-items": "^1.1253.1229",
     "warframe-nexus-query": "^1.6.16",
     "warframe-worldstate-data": "^1.23.8",
-    "warframe-worldstate-parser": "^2.23.2",
+    "warframe-worldstate-parser": "^2.24.0",
     "winston": "^3.7.2",
     "worldstate-emitter": "^1.0.8",
     "ws": "^7.5.8"


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
N/A

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[Yes]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Enhancement]**
