### PR TITLE
feat: allow search with nested keys

### DIFF
--- a/src/spec/items.spec.js
+++ b/src/spec/items.spec.js
@@ -115,6 +115,57 @@ describe('items', () => {
     res.body.should.be.an('array');
     res.body.length.should.eq(0);
   });
+  it('should return an item by a non-default key', async () => {
+    const res = await chai.request(server).get('/items/bronco.png?by=imageName');
+    res.should.have.status(200);
+    res.body.should.be.an('object');
+    Object.keys(res.body).length.should.be.greaterThan(0);
+  });
+  it('should return multiple items by a non-default key', async () => {
+    const res = await chai.request(server).get('/items/search/bronco.png?by=imageName');
+    res.should.have.status(200);
+    res.body.should.be.an('array');
+    res.body.length.should.be.greaterThan(0);
+  });
+  it('should return an item by nested keys', async () => {
+    const res = await chai.request(server).get('/items/7?by=attacks.falloff.start');
+    res.should.have.status(200);
+    res.body.should.be.an('object');
+    Object.keys(res.body).length.should.be.greaterThan(0);
+    res.body.uniqueName.should.eq('/Lotus/Weapons/Tenno/Pistol/HandShotGun');
+  });
+  it('should give error for unmatchable nested keys', async () => {
+    let res = await chai.request(server).get('/items/bronco?by=components.shoobedowopwah');
+    res.should.have.status(404);
+    res.body.should.be.an('object');
+    res.body.error.should.eq('No Result');
+    res.body.code.should.eq(404);
+
+    res = await chai.request(server).get('/items/rare?by=components.rarity');
+    res.should.have.status(404);
+    res.body.should.be.an('object');
+    res.body.error.should.eq('No Result');
+    res.body.code.should.eq(404);
+  });
+  it('should return multiple items by nested keys', async () => {
+    const res = await chai.request(server).get('/items/search/7?by=attacks.falloff.start');
+    res.should.have.status(200);
+    res.body.should.be.an('array');
+    res.body.length.should.eq(2);
+    res.body[0].uniqueName.should.eq('/Lotus/Weapons/Tenno/Akimbo/AkimboShotGun');
+    res.body[1].uniqueName.should.eq('/Lotus/Weapons/Tenno/Pistol/HandShotGun');
+  });
+  it('should return empty array for unmatchable nested keys', async () => {
+    let res = await chai.request(server).get('/items/search/bronco?by=components.shoobedowopwah');
+    res.should.have.status(200);
+    res.body.should.be.an('array');
+    res.body.length.should.eq(0);
+
+    res = await chai.request(server).get('/items/search/rare?by=components.rarity');
+    res.should.have.status(200);
+    res.body.should.be.an('array');
+    res.body.length.should.eq(0);
+  });
 });
 
 describe('weapons', () => {


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
No existing issue.
Adds the capability for 'by' query parameters to use nested keys such as the following api call that will return all weapons that require a component with a name containing 'plastids':
`/weapons/search/plastids?by=components.name`

Updates value comparisons to stringify values, allowing for matching non-string values.

---

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement**
