### PR TITLE
feat: replace arsenal-parser with profile-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@sentry/node": "^7.113.0",
         "@sentry/tracing": "^7.113.0",
         "@wfcd/arsenal-parser": "^2.0.2",
+        "@wfcd/profile-parser": "^1.0.2",
         "apicache": "^1.6.3",
         "colors": "1.4.0",
         "cors": "^2.8.5",
@@ -44,7 +45,7 @@
         "@types/helmet": "4.0.0",
         "@types/twitter": "^1.7.4",
         "@types/ws": "^8.5.3",
-        "@wfcd/eslint-config": "*",
+        "@wfcd/eslint-config": "latest",
         "c8": "^9.1.0",
         "chai": "^4.4.1",
         "chai-http": "^4.4.0",
@@ -2937,6 +2938,18 @@
         "eslint-plugin-no-null": "^1.0.2",
         "eslint-plugin-prettier": "^5.1.3",
         "prettier": "^3.2.5"
+      }
+    },
+    "node_modules/@wfcd/profile-parser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@wfcd/profile-parser/-/profile-parser-1.0.2.tgz",
+      "integrity": "sha512-0iRyRWizdZyu4FWDjzHMa5DwoM5rgaqeGI1BKwubyA5AzPRrp2Q+G+PMx0glW6kKGaXSXtFS2vo3sOuwmrPmhg==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "warframe-items": "^1.1262.30",
+        "warframe-worldstate-data": "^2.5.0"
       }
     },
     "node_modules/abbrev": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "warframe-status",
-      "version": "1.14.9",
+      "version": "1.13.33",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@sentry/node": "^7.113.0",
     "@sentry/tracing": "^7.113.0",
     "@wfcd/arsenal-parser": "^2.0.2",
+    "@wfcd/profile-parser": "^1.0.2",
     "apicache": "^1.6.3",
     "colors": "1.4.0",
     "cors": "^2.8.5",

--- a/src/controllers/profile.js
+++ b/src/controllers/profile.js
@@ -1,17 +1,55 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import ArsenalParser from '@wfcd/arsenal-parser';
 import ProfileParser from '@wfcd/profile-parser';
 import express from 'express';
+import flatCache from 'flat-cache';
 
+import settings from '../lib/settings.js';
 import { cache, noResult } from '../lib/utilities.js';
 
 const router = express.Router({ strict: true });
-const WF_PROFILE_API = 'https://content.warframe.com/dynamic/getProfileViewingData.php';
 
-router.get('/:username/?', cache('1 hour'), async (req, res) => {
-  const profileUrl = `${WF_PROFILE_API}?n=${encodeURIComponent(req.params.username)}`;
+router.get('/:username/?', cache('1 minute'), async (req, res) => {
+  const profileUrl = `${settings.wfApi.profile}?n=${encodeURIComponent(req.params.username)}`;
   const data = await fetch(profileUrl, { headers: { 'User-Agent': process.env.USER_AGENT || 'Node.js Fetch' } });
   if (data.status !== 200) noResult(res);
 
   return res.status(200).json(new ProfileParser(await data.json()));
+});
+
+let token;
+const dirName = dirname(fileURLToPath(import.meta.url));
+
+router.use((req, res, next) => {
+  const tokenCache = flatCache.load('.twitch', resolve(dirName, '../../'));
+  token = tokenCache.getKey('token');
+  next();
+});
+
+router.get(`/:username/arsenal/?`, cache('1 hour'), async (req, res) => {
+  const { id, api } = settings.wfApi.arsenal;
+
+  /* istanbul ignore if */
+  if (!token || token === 'unset') {
+    return res.status(503).json({ code: 503, error: 'Service Unavailable' });
+  }
+  if (req.platform !== 'pc') return noResult(res);
+  const profileUrl = `${api}?account=${encodeURIComponent(req.params.username.toLowerCase())}`;
+  const data = await fetch(profileUrl, {
+    headers: {
+      'User-Agent': process.env.USER_AGENT || 'Node.js Fetch',
+      Origin: `https://${id}.ext-twitch.tv`,
+      Referer: `https://${id}.ext-twitch.tv`,
+      Authorization: `Bearer ${token}`,
+    },
+  }).then((d) => d.json());
+  /* istanbul ignore if */
+  if (!data.accountInfo) {
+    return noResult(res);
+  }
+  return res.status(200).json(new ArsenalParser(data));
 });
 
 export default router;

--- a/src/controllers/profile.js
+++ b/src/controllers/profile.js
@@ -35,6 +35,14 @@ router.get('/:username/xpInfo/?', cache('1 minute'), async (req, res) => {
   return res.status(200).json(data.profile.loadout.xpInfo);
 });
 
+router.get('/:username/stats/?', cache('1 minute'), async (req, res) => {
+  let data = await get(req.params.username);
+  if (!data) return noResult(res);
+
+  data = new ProfileParser(data);
+  return res.status(200).json(data.stats);
+});
+
 let token;
 const dirName = dirname(fileURLToPath(import.meta.url));
 

--- a/src/controllers/profile.js
+++ b/src/controllers/profile.js
@@ -20,14 +20,14 @@ const get = async (username) => {
   return data.json();
 };
 
-router.get('/:username/?', cache('1 minute'), async (req, res) => {
+router.get('/:username/?', cache('1 hour'), async (req, res) => {
   const profile = await get(req.params.username);
   if (!profile) return noResult(res);
 
   return res.status(200).json(new ProfileParser(profile));
 });
 
-router.get('/:username/xpInfo/?', cache('1 minute'), async (req, res) => {
+router.get('/:username/xpInfo/?', cache('1 hour'), async (req, res) => {
   let data = await get(req.params.username);
   if (!data) return noResult(res);
 
@@ -35,7 +35,7 @@ router.get('/:username/xpInfo/?', cache('1 minute'), async (req, res) => {
   return res.status(200).json(data.profile.loadout.xpInfo);
 });
 
-router.get('/:username/stats/?', cache('1 minute'), async (req, res) => {
+router.get('/:username/stats/?', cache('1 hour'), async (req, res) => {
   let data = await get(req.params.username);
   if (!data) return noResult(res);
 

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -1,7 +1,7 @@
 import dns from 'node:dns/promises';
 
-import { Address6, Address4 } from 'ip-address';
 import dotenv from 'dotenv';
+import { Address4, Address6 } from 'ip-address';
 
 import makeLogger from './logger.js';
 
@@ -60,6 +60,14 @@ export const admin = {
 };
 export const features = process.env.FEATURES?.split(',') || [];
 
+export const wfApi = {
+  profile: 'https://content.warframe.com/dynamic/getProfileViewingData.php',
+  arsenal: {
+    id: 'ud1zj704c0eb1s553jbkayvqxjft97',
+    api: 'https://content.warframe.com/dynamic/twitch/getActiveLoadout.php',
+  },
+};
+
 const settings = {
   twitter,
   wfInfo,
@@ -72,6 +80,7 @@ const settings = {
   env,
   admin,
   features,
+  wfApi,
 };
 
 export default process.env.NODE_ENV === 'test' ? settings : Object.freeze(settings);

--- a/src/spec/profile.spec.js
+++ b/src/spec/profile.spec.js
@@ -16,9 +16,51 @@ describe('profiles', () => {
       res.body?.profile.should.include.keys('accountId', 'displayName', 'masteryRank', 'created');
       res.body.profile.displayName.should.eq('Tobiah');
     });
-
     it('should error with bad username', async () => {
       const res = await chai.request(server).get('/profile/asdasdaasdaasasdasdaasdaasdaasdasdaasdaasda');
+      res.should.have.status(404);
+      res.body.should.be.an('object').and.include.all.keys('code', 'error');
+      res.body.code.should.eq(404);
+      res.body.error.should.eq('No Result');
+    });
+  });
+  describe('/profile/:username/arsenal', async () => {
+    describe('should get profile data', async () => {
+      it('pc [default]', async () => {
+        const res = await chai.request(server).get('/profile/tobiah/arsenal');
+        res.should.have.status(200);
+        should.exist(res.body);
+        res.body.should.include.keys('account', 'loadout');
+        res.body?.account.should.include.keys('name', 'masteryRank', 'lastUpdated', 'glyph');
+        res.body.account.name.should.eq('Tobiah');
+      });
+      it.skip('xbox', async () => {
+        const res = await chai.request(server).get('/profile/MrNishi/arsenal/?platform=xb1');
+        res.should.have.status(200);
+        should.exist(res.body);
+        res.body.should.include.keys('account', 'loadout');
+        res.body?.account.should.include.keys('name', 'masteryRank', 'lastUpdated', 'glyph');
+        res.body.account.name.should.eq('[DE]Megan');
+      });
+      it.skip('psn', async () => {
+        const res = await chai.request(server).get('/profile/ErydisTheLucario/arsenal/?platform=ps4');
+        res.should.have.status(200);
+        should.exist(res.body);
+        res.body.should.include.keys('account', 'loadout');
+        res.body?.account.should.include.keys('name', 'masteryRank', 'lastUpdated', 'glyph');
+        res.body.account.name.should.eq('povo844');
+      });
+      it('switch', async () => {
+        const res = await chai.request(server).get('/profile/tobiah/arsenal/').set('platform', 'swi');
+        res.should.have.status(200);
+        should.exist(res.body);
+        res.body.should.include.keys('account', 'loadout');
+        res.body?.account.should.include.keys('name', 'masteryRank', 'lastUpdated', 'glyph');
+        res.body.account.name.should.eq('Tobiah');
+      });
+    });
+    it('should error with bad username', async () => {
+      const res = await chai.request(server).get('/profile/asdasdaasdaasasdasdaasdaasdaasdasdaasdaasda/arsenal/');
       res.should.have.status(404);
       res.body.should.be.an('object').and.include.all.keys('code', 'error');
       res.body.code.should.eq(404);

--- a/src/spec/profile.spec.js
+++ b/src/spec/profile.spec.js
@@ -67,4 +67,19 @@ describe('profiles', () => {
       res.body.error.should.eq('No Result');
     });
   });
+  describe('/profile/:username/xpInfo', async () => {
+    it('should get profile xp info', async () => {
+      const res = await chai.request(server).get('/profile/tobiah/xpInfo');
+      res.should.have.status(200);
+      should.exist(res.body);
+      res.body[0].should.include.keys('uniqueName', 'xp', 'item');
+    });
+    it('should error with bad username', async () => {
+      const res = await chai.request(server).get('/profile/asdasdaasdaasasdasdaasdaasdaasdasdaasdaasda');
+      res.should.have.status(404);
+      res.body.should.be.an('object').and.include.all.keys('code', 'error');
+      res.body.code.should.eq(404);
+      res.body.error.should.eq('No Result');
+    });
+  });
 });

--- a/src/spec/profile.spec.js
+++ b/src/spec/profile.spec.js
@@ -75,7 +75,22 @@ describe('profiles', () => {
       res.body[0].should.include.keys('uniqueName', 'xp', 'item');
     });
     it('should error with bad username', async () => {
-      const res = await chai.request(server).get('/profile/asdasdaasdaasasdasdaasdaasdaasdasdaasdaasda');
+      const res = await chai.request(server).get('/profile/asdasdaasdaasasdasdaasdaasdaasdasdaasdaasda/xpInfo');
+      res.should.have.status(404);
+      res.body.should.be.an('object').and.include.all.keys('code', 'error');
+      res.body.code.should.eq(404);
+      res.body.error.should.eq('No Result');
+    });
+  });
+  describe('/profile/:username/xpInfo', async () => {
+    it('should get profile stats', async () => {
+      const res = await chai.request(server).get('/profile/tobiah/stats');
+      res.should.have.status(200);
+      should.exist(res.body);
+      res.body.should.include.keys('guildName', 'xp', 'missionsCompleted');
+    });
+    it('should error with bad username', async () => {
+      const res = await chai.request(server).get('/profile/asdasdaasdaasasdasdaasdaasdaasdasdaasdaasda/stats');
       res.should.have.status(404);
       res.body.should.be.an('object').and.include.all.keys('code', 'error');
       res.body.code.should.eq(404);

--- a/src/spec/profile.spec.js
+++ b/src/spec/profile.spec.js
@@ -8,42 +8,17 @@ chai.use(chaiHttp);
 
 describe('profiles', () => {
   describe('/profile/:username', async () => {
-    describe('should get profile data', () => {
-      it('pc [default]', async () => {
-        const res = await chai.request(server).get('/profile/tobiah/');
-        res.should.have.status(200);
-        should.exist(res.body);
-        res.body.should.include.keys('account', 'loadout');
-        res.body?.account.should.include.keys('name', 'masteryRank', 'lastUpdated', 'glyph');
-        res.body.account.name.should.eq('Tobiah');
-      });
-      it.skip('xbox', async () => {
-        const res = await chai.request(server).get('/profile/MrNishi/?platform=xb1');
-        res.should.have.status(200);
-        should.exist(res.body);
-        res.body.should.include.keys('account', 'loadout');
-        res.body?.account.should.include.keys('name', 'masteryRank', 'lastUpdated', 'glyph');
-        res.body.account.name.should.eq('[DE]Megan');
-      });
-      it.skip('psn', async () => {
-        const res = await chai.request(server).get('/profile/ErydisTheLucario/?platform=ps4');
-        res.should.have.status(200);
-        should.exist(res.body);
-        res.body.should.include.keys('account', 'loadout');
-        res.body?.account.should.include.keys('name', 'masteryRank', 'lastUpdated', 'glyph');
-        res.body.account.name.should.eq('povo844');
-      });
-      it('switch', async () => {
-        const res = await chai.request(server).get('/profile/tobiah').set('platform', 'swi');
-        res.should.have.status(200);
-        should.exist(res.body);
-        res.body.should.include.keys('account', 'loadout');
-        res.body?.account.should.include.keys('name', 'masteryRank', 'lastUpdated', 'glyph');
-        res.body.account.name.should.eq('Tobiah');
-      });
+    it('should get profile data', async () => {
+      const res = await chai.request(server).get('/profile/tobiah/');
+      res.should.have.status(200);
+      should.exist(res.body);
+      res.body.should.include.keys('profile', 'stats');
+      res.body?.profile.should.include.keys('accountId', 'displayName', 'masteryRank', 'created');
+      res.body.profile.displayName.should.eq('Tobiah');
     });
+
     it('should error with bad username', async () => {
-      const res = await chai.request(server).get('/profile/asdasdaasdaasasdasdaasdaasdaasdasdaasdaasda/?platform=xb1');
+      const res = await chai.request(server).get('/profile/asdasdaasdaasasdasdaasdaasdaasdasdaasdaasda');
       res.should.have.status(404);
       res.body.should.be.an('object').and.include.all.keys('code', 'error');
       res.body.code.should.eq(404);


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Replace arsenal-parser with [profile-parser](https://github.com/WFCD/profile-parser) so that we can parse the results from https://content.warframe.com/dynamic/getProfileViewingData.php?n=${username} into an easy consumable response

This commit will also create a breaking change since it will completely change the response structure for `/profile` endpoint

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **Yes**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Feature**
