### PR TITLE
Add vaultTrader endpoint docs

### DIFF
--- a/src/api-spec/openapi.json
+++ b/src/api-spec/openapi.json
@@ -1177,6 +1177,43 @@
         }
       }
     },
+    "/{platform}/vaultTrader": {
+      "get": {
+        "tags": [
+          "Worldstate"
+        ],
+        "summary": "Get current Varzia Information",
+        "description": "Information on the current Vault Trader (Varzia) items, and previous offerings.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/platform"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "headers": {
+              "Content-Language": {
+                "$ref": "#/components/headers/Content-Language"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/vaultTrader"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/error"
+          },
+          "500": {
+            "$ref": "#/components/responses/error"
+          }
+        }
+      }
+    },
     "/arcanes": {
       "get": {
         "tags": [
@@ -6350,6 +6387,105 @@
           "endString": {
             "minLength": 1,
             "type": "string"
+          }
+        }
+      },
+      "vaultTrader": {
+        "required": [
+          "activation",
+          "active",
+          "character",
+          "endString",
+          "expiry",
+          "id",
+          "inventory",
+          "location",
+          "psId",
+          "startString",
+          "initialStart",
+          "schedule"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "activation": {
+            "minLength": 1,
+            "type": "string",
+            "format": "date-time"
+          },
+          "expiry": {
+            "minLength": 1,
+            "type": "string",
+            "format": "date-time"
+          },
+          "character": {
+            "minLength": 0,
+            "type": "string"
+          },
+          "location": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "inventory": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "uniqueName": {
+                  "type": "string"
+                },
+                "item": {
+                  "type": "string"
+                },
+                "ducats": {
+                  "type": "number"
+                },
+                "credits": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "psId": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "startString": {
+            "minLength": 1,
+            "type": "string",
+            "format": "date-time"
+          },
+          "initialStart": {
+            "minLength": 1,
+            "type": "string",
+            "format": "date-time"
+          },
+          "endString": {
+            "minLength": 1,
+            "type": "string",
+            "format": "date-time"
+          },
+          "schedule": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "expiry": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "item": {
+                  "type": "string",
+                  "description": "The current prime pack"
+                }
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Adds documentation for the /{platform}/vaultTrader/ endpoint.

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->
//

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->
![image](https://github.com/WFCD/warframe-status/assets/69414142/938176fc-524a-46f4-a3e6-485dd3885ad1)
![image](https://github.com/WFCD/warframe-status/assets/69414142/1ca8602b-3a4d-4d6b-bf2c-0d8ab0fb45d4)


### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Docs]**
