### PR TITLE
perf(profile): parse out `Stats`,`xpInfo`, and `Profile` separately

### DIFF
--- a/src/controllers/profile.js
+++ b/src/controllers/profile.js
@@ -4,12 +4,12 @@ import { fileURLToPath } from 'node:url';
 import ArsenalParser from '@wfcd/arsenal-parser';
 import express from 'express';
 import flatCache from 'flat-cache';
-
 import Profile from '@wfcd/profile-parser/Profile';
 import Stats from '@wfcd/profile-parser/Stats';
 import XpInfo from '@wfcd/profile-parser/XpInfo';
-import settings from '../lib/settings.js';
+
 import { cache, noResult } from '../lib/utilities.js';
+import settings from '../lib/settings.js';
 
 const router = express.Router({ strict: true });
 
@@ -30,7 +30,7 @@ router.get('/:username/?', cache('1 hour'), async (req, res) => {
 });
 
 router.get('/:username/xpInfo/?', cache('1 hour'), async (req, res) => {
-  let data = await get(req.params.username);
+  const data = await get(req.params.username);
   if (!data) return noResult(res);
 
   const xpInfo = data.Results[0].LoadOutInventory.XPInfo.map((xp) => new XpInfo(xp));
@@ -38,7 +38,7 @@ router.get('/:username/xpInfo/?', cache('1 hour'), async (req, res) => {
 });
 
 router.get('/:username/stats/?', cache('1 hour'), async (req, res) => {
-  let data = await get(req.params.username);
+  const data = await get(req.params.username);
   if (!data) return noResult(res);
 
   return res.status(200).json(new Stats(data.Stats));

--- a/src/controllers/profile.js
+++ b/src/controllers/profile.js
@@ -2,10 +2,12 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import ArsenalParser from '@wfcd/arsenal-parser';
-import ProfileParser from '@wfcd/profile-parser';
 import express from 'express';
 import flatCache from 'flat-cache';
 
+import Profile from '@wfcd/profile-parser/Profile';
+import Stats from '@wfcd/profile-parser/Stats';
+import XpInfo from '@wfcd/profile-parser/XpInfo';
 import settings from '../lib/settings.js';
 import { cache, noResult } from '../lib/utilities.js';
 
@@ -24,23 +26,22 @@ router.get('/:username/?', cache('1 hour'), async (req, res) => {
   const profile = await get(req.params.username);
   if (!profile) return noResult(res);
 
-  return res.status(200).json(new ProfileParser(profile));
+  return res.status(200).json(new Profile(profile.Results[0]));
 });
 
 router.get('/:username/xpInfo/?', cache('1 hour'), async (req, res) => {
   let data = await get(req.params.username);
   if (!data) return noResult(res);
 
-  data = new ProfileParser(data);
-  return res.status(200).json(data.profile.loadout.xpInfo);
+  const xpInfo = data.Results[0].LoadOutInventory.XPInfo.map((xp) => new XpInfo(xp));
+  return res.status(200).json(xpInfo);
 });
 
 router.get('/:username/stats/?', cache('1 hour'), async (req, res) => {
   let data = await get(req.params.username);
   if (!data) return noResult(res);
 
-  data = new ProfileParser(data);
-  return res.status(200).json(data.stats);
+  return res.status(200).json(new Stats(data.Stats));
 });
 
 let token;

--- a/src/spec/profile.spec.js
+++ b/src/spec/profile.spec.js
@@ -12,9 +12,8 @@ describe('profiles', () => {
       const res = await chai.request(server).get('/profile/tobiah/');
       res.should.have.status(200);
       should.exist(res.body);
-      res.body.should.include.keys('profile', 'stats');
-      res.body?.profile.should.include.keys('accountId', 'displayName', 'masteryRank', 'created');
-      res.body.profile.displayName.should.eq('Tobiah');
+      res.body.should.include.keys('accountId', 'displayName', 'masteryRank', 'created');
+      res.body.displayName.should.eq('Tobiah');
     });
     it('should error with bad username', async () => {
       const res = await chai.request(server).get('/profile/asdasdaasdaasasdasdaasdaasdaasdasdaasdaasda');


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Right now when we make a GET request to `/profile/:username`  and any of it's sub path the entire user profile is parsed causing long wait times when parsing player's with more items.

With this PR instead of parsing the whole profile we can pick out the parts that we need and just parse those bits instead. XPInfo will still take a long time though

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Enhancement**
