### PR TITLE
feat(ws,items): dynamic filters

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -8,6 +8,7 @@
     "PORT": 3001,
     "CACHE_TIMEOUT": 30000,
     "DISABLE_PRICECHECKS": "true",
-    "USER_AGENT": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36"
+    "USER_AGENT": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36",
+    "FEATURES": "SOCKET"
   }
 }

--- a/src/controllers/items.js
+++ b/src/controllers/items.js
@@ -4,7 +4,15 @@ import { noResult, trimPlatform, cache, ah } from '../lib/utilities.js';
 import Items from '../lib/caches/Items.js';
 
 const router = express.Router();
-const splitKeys = (input) => (input || '').split(',').filter((k) => k.length);
+const splitKeys = (input) => (input || '').split(',').filter(Boolean);
+const splitFilter = (input) =>
+  (input || '')
+    .split(',')
+    .filter(Boolean)
+    .map((i) => {
+      const [key, value] = i.split(':');
+      return { key, value };
+    });
 
 router.use((req, res, next) => {
   req.itemType = trimPlatform(req.baseUrl);
@@ -43,11 +51,12 @@ router.use((req, res, next) => {
 router.get(
   '/',
   ah(async (req, res) => {
-    const { remove, only } = req.query;
+    const { remove, only, filter } = req.query;
     return res.status(200).json(
       await Items.get(req.itemType, req.language, {
         remove: splitKeys(remove),
         only: splitKeys(only),
+        filter: splitFilter(filter),
       })
     );
   })
@@ -89,11 +98,12 @@ router.get(
   '/:item/?',
   cache('10 hours'),
   ah(async (req, res) => {
-    const { remove, only } = req.query;
+    const { remove, only, filter, by } = req.query;
     const result = await Items.get(req.itemType, req.language, {
-      by: req.query.by,
+      by,
       only: splitKeys(only),
       remove: splitKeys(remove),
+      filter: splitFilter(filter),
       max: 1,
       term: req.params.item,
     });
@@ -141,7 +151,7 @@ router.get(
   '/search/:query/?',
   cache('10 hours'),
   ah(async (req, res) => {
-    const { remove, only, by = 'name' } = req.query;
+    const { remove, only, by = 'name', filter } = req.query;
     const queries = req.params.query
       .trim()
       .split(',')
@@ -155,6 +165,7 @@ router.get(
           only: splitKeys(only),
           term: query,
           max: 0,
+          filter: splitFilter(filter),
         })
       );
     }

--- a/src/controllers/worldstate.js
+++ b/src/controllers/worldstate.js
@@ -21,6 +21,17 @@ const redirectCheck = (req, res) => {
   return false;
 };
 
+const filterArray = (req, data) => {
+  let filtered = data;
+  if (req.query.filter) {
+    req.query.filter.split(',').forEach((filter) => {
+      const [key, value] = filter.split(':');
+      filtered = filtered.filter((item) => String(item[key]) === value);
+    });
+  }
+  return filtered;
+};
+
 const router = express.Router({ strict: true });
 
 router.use((req, res, next) => {
@@ -48,9 +59,17 @@ router.get('/:field/?', (req, res) => {
   const ws = get(req.platform, req.language);
   if (ws?.[req.params.field]) {
     res.setHeader('Content-Language', req.language);
+    if (Array.isArray(ws[req.params.field])) {
+      res.json(filterArray(req, ws[req.params.field]));
+      return;
+    }
     res.json(ws[req.params.field]);
   } else if (req.params.field && languages.includes(req.params.field.substring(0, 2).toLowerCase())) {
     const ows = get(req.platform, req.params.field.substring(0, 2).toLowerCase());
+    if (Array.isArray(ows)) {
+      res.json(filterArray(req, ows));
+      return;
+    }
     res.json(ows);
   } else if (!res.writableEnded) {
     res.status(404).json({ error: 'No such worldstate field', code: 404 });
@@ -62,10 +81,15 @@ router.get('/:language/:field/?', cache('1 minute'), (req, res) => {
     req.language = req.params.language.substring(0, 2).toLowerCase();
   }
   const ws = get(req.platform, req.language);
+  const fieldData = ws?.[req.params.field];
 
-  if (ws?.[req.params.field]) {
+  if (fieldData) {
     res.setHeader('Content-Language', req.language);
-    res.json(ws[req.params.field]);
+    if (Array.isArray(fieldData)) {
+      res.json(filterArray(req, fieldData));
+      return;
+    }
+    res.json(fieldData);
   } else if (!res.writableEnded) {
     res.status(404).json({ error: 'No such worldstate field', code: 404 });
   }

--- a/src/spec/items.spec.js
+++ b/src/spec/items.spec.js
@@ -31,6 +31,20 @@ describe('items', () => {
     res.body[0].should.not.have.property('uniqueName');
     res.body[0].should.not.have.property('description');
   });
+  it('should filter with desired key:value pairs', async () => {
+    const res = await chai
+      .request(server)
+      .get('/items?only=name,category,introduced&filter=category:Warframes,introduced.name:Vanilla');
+    res.should.have.status(200);
+    res.body.should.be.an('array');
+    res.body.length.should.be.eq(8);
+    res.body.forEach((item) => {
+      item.should.have.property('name');
+      item.should.have.property('category', 'Warframes');
+      item.should.have.property('introduced');
+      item.introduced.name.should.eq('Vanilla');
+    });
+  });
   it('should only include desired keys from dump', async () => {
     const res = await chai.request(server).get('/items?only=uniqueName,description');
     res.should.have.status(200);


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
implement pretty verbose, expansive filters

on worldstate:
- adds `filter` query param
	- structure `filter=({key}:{value})*`
	- ex: `filter=syndicateKey:Ostrons`

on items:
- adds `filter` query param
	- structure `filter=({key}:{value})*`
		- ex: `filter=category:Warframes`
	- supports nested keys
		- ex: `filter=category:Warframes,introduced.name:Vanilla`


---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[Yes]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Feature]**
