### PR TITLE
fix: pass query language to Profile

### DIFF
--- a/src/controllers/profile.js
+++ b/src/controllers/profile.js
@@ -26,7 +26,7 @@ router.get('/:username/?', cache('1 hour'), async (req, res) => {
   const profile = await get(req.params.username);
   if (!profile) return noResult(res);
 
-  return res.status(200).json(new Profile(profile.Results[0]));
+  return res.status(200).json(new Profile(profile.Results[0], req.language));
 });
 
 router.get('/:username/xpInfo/?', cache('1 hour'), async (req, res) => {


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Actually pass the language query to Profile constructor

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
