### PR TITLE
fix: `imageName` missing in warframe abilities

### DIFF
--- a/src/lib/caches/Items.js
+++ b/src/lib/caches/Items.js
@@ -62,19 +62,21 @@ const makeLanguageCache = (language) => {
     merged[cacheType] = [...subCache].map((item) => {
       let itemClone = { ...item };
       if (language !== 'en' && itemClone.i18n && itemClone.i18n[language]) {
+        // Abilties are always sorted from first to fourth ability so using the index is safe
+        // Thanks DE :)
+        itemClone.i18n[language].abilities = itemClone.i18n[language].abilities?.map((ability, index) => ({
+          uniqueName: ability.abilityUniqueName || itemClone.abilities[index].uniqueName || undefined,
+          name: ability.abilityName || itemClone.abilities[index].name || undefined,
+          description: ability.description || itemClone.abilities[index].description || undefined,
+          imageName: itemClone.abilities[index].imageName ?? undefined,
+        }));
+
         itemClone = {
           ...itemClone,
           ...itemClone.i18n[language],
         };
       }
-      if (itemClone.abilities) {
-        itemClone.abilities = itemClone.abilities.map((ability) => ({
-          uniqueName: ability.abilityUniqueName || ability.uniqueName || undefined,
-          name: ability.abilityName || ability.name,
-          description: ability.abilityDescription || ability.description,
-          imageName: ability.imageName ?? undefined,
-        }));
-      }
+
       delete itemClone.i18n;
       return itemClone;
     });


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Fixes a weird case where `imageName` disappeared from warframe abilities 

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **Yes**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
