### PR TITLE
fix: pin dockerfile to iron-alpine from lts-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:lts-alpine AS build
+FROM node:iron-alpine AS build
 
 COPY package*.json ./
 RUN npm install
 
-FROM node:lts-alpine AS production
+FROM node:iron-alpine AS production
 
 WORKDIR /app
 


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
iron-alpine instead of lts-alpine in images

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[Yes]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Maintenance]**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated base Docker image to the latest Node.js Iron Alpine version for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->