### PR TITLE
fix: use `playerId` whenfetching profile from DE

### DIFF
--- a/src/controllers/profile.js
+++ b/src/controllers/profile.js
@@ -11,7 +11,7 @@ import settings from '../lib/settings.js';
 const router = express.Router({ strict: true });
 
 const get = async (username) => {
-  const profileUrl = `${settings.wfApi.profile}?n=${encodeURIComponent(username)}`;
+  const profileUrl = `${settings.wfApi.profile}?playerId=${encodeURIComponent(username)}`;
   const data = await fetch(profileUrl, { headers: { 'User-Agent': process.env.USER_AGENT || 'Node.js Fetch' } });
 
   if (data.status !== 200) return undefined;

--- a/src/controllers/profile.js
+++ b/src/controllers/profile.js
@@ -10,8 +10,8 @@ import settings from '../lib/settings.js';
 
 const router = express.Router({ strict: true });
 
-const get = async (username) => {
-  const profileUrl = `${settings.wfApi.profile}?playerId=${encodeURIComponent(username)}`;
+const get = async (id) => {
+  const profileUrl = `${settings.wfApi.profile}?playerId=${encodeURIComponent(id)}`;
   const data = await fetch(profileUrl, { headers: { 'User-Agent': process.env.USER_AGENT || 'Node.js Fetch' } });
 
   if (data.status !== 200) return undefined;
@@ -19,14 +19,14 @@ const get = async (username) => {
   return data.json();
 };
 
-router.get('/:username/?', cache('1 hour'), async (req, res) => {
+router.get('/:playerId/?', cache('1 hour'), async (req, res) => {
   const profile = await get(req.params.username);
   if (!profile) return noResult(res);
 
   return res.status(200).json(new Profile(profile.Results[0], req.language));
 });
 
-router.get('/:username/xpInfo/?', cache('1 hour'), async (req, res) => {
+router.get('/:playerId/xpInfo/?', cache('1 hour'), async (req, res) => {
   const data = await get(req.params.username);
   if (!data) return noResult(res);
 
@@ -34,7 +34,7 @@ router.get('/:username/xpInfo/?', cache('1 hour'), async (req, res) => {
   return res.status(200).json(xpInfo);
 });
 
-router.get('/:username/stats/?', cache('1 hour'), async (req, res) => {
+router.get('/:playerId/stats/?', cache('1 hour'), async (req, res) => {
   const data = await get(req.params.username);
   if (!data) return noResult(res);
 


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
`https://content.warframe.com/dynamic/getProfileViewingData.php?n=(username)` is now `https://content.warframe.com/dynamic/getProfileViewingData.php?playerId=(account id)` 

This requires account ID which can be found in `EE.log`

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated profile data retrieval to use the correct user identifier, ensuring that profiles load reliably and consistently for a smoother experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->