### PR TITLE
ci(fix): dependabot prefix for warframe deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: 'daily'
       time: '00:00'
     commit-message:
-      prefix: "ci"
+      prefix: 'ci'
     labels:
       - 'Scope: Dependencies'
       - 'Type: Maintenance'
@@ -19,6 +19,7 @@ updates:
         patterns:
           - '@sentry/'
       warframe:
+        prefix: 'fix'
         patterns:
           - '@wfcd/'
           - 'warframe-*'
@@ -56,7 +57,7 @@ updates:
       day: 'saturday'
       time: '00:00'
     commit-message:
-      prefix: "ci"
+      prefix: 'ci'
     labels:
       - 'Scope: Dependencies'
       - 'Type: Maintenance'


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
make warframe dependency updates trigger patches

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Maintenance]**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved dependency update configuration with standardized commit message prefixes.
  - Enhanced grouping for dependency updates through new configuration adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->