### PR TITLE
fix: profile endpoints not using the proper params

### DIFF
--- a/src/controllers/profile.js
+++ b/src/controllers/profile.js
@@ -20,14 +20,14 @@ const get = async (id) => {
 };
 
 router.get('/:playerId/?', cache('1 hour'), async (req, res) => {
-  const profile = await get(req.params.username);
+  const profile = await get(req.params.playerId);
   if (!profile) return noResult(res);
 
   return res.status(200).json(new Profile(profile.Results[0], req.language));
 });
 
 router.get('/:playerId/xpInfo/?', cache('1 hour'), async (req, res) => {
-  const data = await get(req.params.username);
+  const data = await get(req.params.playerId);
   if (!data) return noResult(res);
 
   const xpInfo = data.Results[0].LoadOutInventory.XPInfo.map((xp) => new XpInfo(xp));


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
My fault, I forgot to change the params from `username` to `playerId` in #1840 

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined player profile and experience data endpoints by standardizing the identification parameter for a more consistent and reliable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->