### PR TITLE
fix: playerId in profile-stats

### DIFF
--- a/src/controllers/profile.js
+++ b/src/controllers/profile.js
@@ -35,7 +35,7 @@ router.get('/:playerId/xpInfo/?', cache('1 hour'), async (req, res) => {
 });
 
 router.get('/:playerId/stats/?', cache('1 hour'), async (req, res) => {
-  const data = await get(req.params.username);
+  const data = await get(req.params.playerId);
   if (!data) return noResult(res);
 
   return res.status(200).json(new Stats(data.Stats));


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
fixes stats not inheriting playerId

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the player statistics endpoint to use the correct identifier, ensuring that profiles display the accurate data based on the URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->