### PR TITLE
fix: 404 unknown fields

### DIFF
--- a/src/controllers/worldstate.js
+++ b/src/controllers/worldstate.js
@@ -57,6 +57,10 @@ router.use('/rivens/?', rivens);
 
 router.get('/:field/?', (req, res) => {
   const ws = get(req.platform, req.language);
+  // filter out any fields that can't be language codes (>5 characters)
+  if (!Object.keys(ws).includes(req.params.field) && req.params.field.length > 4) {
+    res.status(404).json({ error: 'No such worldstate field', code: 404 });
+  }
   if (ws?.[req.params.field]) {
     res.setHeader('Content-Language', req.language);
     if (Array.isArray(ws[req.params.field])) {
@@ -81,6 +85,10 @@ router.get('/:language/:field/?', cache('1 minute'), (req, res) => {
     req.language = req.params.language.substring(0, 2).toLowerCase();
   }
   const ws = get(req.platform, req.language);
+  if (!Object.keys(ws).includes(req.params.field)) {
+    res.status(404).json({ error: 'No such worldstate field', code: 404 });
+    return;
+  }
   const fieldData = ws?.[req.params.field];
 
   if (fieldData) {

--- a/src/spec/worldstate.spec.js
+++ b/src/spec/worldstate.spec.js
@@ -60,6 +60,12 @@ data.mods = await grab('mods');
 // because it takes time for the worldstate emitter to get fired up and updating,
 // so this needs to always run last
 describe('worldstate', () => {
+  it('should 404 on invalid worldstate keys', async () => {
+    if (!app.started) should.fail('server not started');
+    // purposeful typo
+    const res = await req(`/pc/deepArchimedia`).redirects(2).send();
+    res.should.have.status(404);
+  });
   platforms.forEach((platform) => {
     describe(`/${platform}`, () => {
       it('should succeed', async () => {


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
weird behavior

---

### Reproduction steps
1. navigate to `http://<host>/pc/deepArchimedia`
2. Yes, that's purposely mis-spelled
3. It should return a standard 404 response
4. navigate to `http://<host>/pc/deepArchimedea`
5. it should return deep archimedea data if it exists, otherwise 404
---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
