### PR TITLE
feat: add a `withItem` query

### DIFF
--- a/src/controllers/profile.js
+++ b/src/controllers/profile.js
@@ -23,14 +23,14 @@ router.get(['/:playerId/', '/:playerId'], cache('1 hour'), async (req, res) => {
   const profile = await get(req.params.playerId);
   if (!profile) return noResult(res);
 
-  return res.status(200).json(new Profile(profile.Results[0], req.language));
+  return res.status(200).json(new Profile(profile.Results[0], req.language, req.query.withItem || false));
 });
 
 router.get(['/:playerId/xpInfo/', '/:playerId/xpInfo'], cache('1 hour'), async (req, res) => {
   const data = await get(req.params.playerId);
   if (!data) return noResult(res);
 
-  const xpInfo = data.Results[0].LoadOutInventory.XPInfo.map((xp) => new XpInfo(xp));
+  const xpInfo = data.Results[0].LoadOutInventory.XPInfo.map((xp) => new XpInfo(xp, req.query.withItem || false));
   return res.status(200).json(xpInfo);
 });
 

--- a/src/spec/profile.spec.js
+++ b/src/spec/profile.spec.js
@@ -67,11 +67,12 @@ describe.skip('profiles', () => {
     });
   });
   describe('/profile/:username/xpInfo', async () => {
-    it('should get profile xp info', async () => {
+    it('should get profile xp info without item', async () => {
       const res = await req('/profile/tobiah/xpInfo');
       res.should.have.status(200);
       should.exist(res.body);
       res.body[0].should.include.keys('uniqueName', 'xp');
+      res.body[0].should.not.property('item');
     });
     it('should error with bad username', async () => {
       const res = await req('/profile/asdasdaasdaasasdasdaasdaasdaasdasdaasdaasda/xpInfo');


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Add a `withItem` query parameter with a default of false. The idea is to reduce response time and data when users just want the profile information without having to wait for the API to fetch every item in `XPInfo`

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Feature**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an optional query parameter to include or exclude item-related data in profile and XP info endpoints.

- **Tests**
  - Updated and expanded tests to verify the presence or absence of item data based on the new query parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->