### PR TITLE
build(docker): bump node from node:iron-alpine to 22.16.0-alpine

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,3 +64,18 @@ updates:
     pull-request-branch-name:
       separator: '-'
     rebase-strategy: 'auto'
+
+  - package-ecosystem: docker
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'saturday'
+      time: '00:00'
+    commit-message:
+      prefix: 'build'
+    labels:
+      - 'Scope: Dependencies'
+      - 'Type: Maintenance'
+    pull-request-branch-name:
+      separator: '-'
+    rebase-strategy: 'auto'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:iron-alpine AS build
+FROM node:22.16.0-alpine AS build
 
 COPY package*.json ./
 RUN npm install
 
-FROM node:iron-alpine AS production
+FROM node:22.16.0-alpine AS production
 
 WORKDIR /app
 


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
There was a security issue with the [previous image](https://hub.docker.com/layers/library/node/iron-alpine/images/sha256-dd75a9e8995e7f9d83f64af16d07c1edbc97139b08246ed8cb7f5ea1d28c726d) 

This commit updates it to a more controlled exact version and enables dependabot for tag updates

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **Yes**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **No**
- Is is a bug fix, feature request, or enhancement? **Maintenance**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enabled automated dependency updates for Docker files with weekly scheduling and custom labeling.
	- Updated Dockerfile to use a specific Node.js version (22.16.0-alpine) for improved consistency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->