### PR TITLE
test: look up item by uniqueName for non-default key test

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "vcs": { "enabled": false, "clientKind": "git", "useIgnoreFile": false },
   "files": {
     "ignoreUnknown": true,

--- a/src/spec/items.spec.js
+++ b/src/spec/items.spec.js
@@ -150,13 +150,17 @@ describe('items', () => {
     res.body.length.should.eq(0);
   });
   it('should return an item by a non-default key', async () => {
-    const res = await req('/items/%2FLotus%2FWeapons%2FTenno%2FPistol%2FHandShotGun/?by=uniqueName');
+    const res = await req(
+      '/items/%2FLotus%2FWeapons%2FTenno%2FPistol%2FHandShotGun/?by=uniqueName',
+    );
     res.should.have.status(200);
     res.body.should.be.an('object');
     Object.keys(res.body).length.should.be.greaterThan(0);
   });
   it('should return multiple items by a non-default key', async () => {
-    const res = await req('/items/search/%2FLotus%2FWeapons%2FTenno%2FPistol%2FHandShotGun/?by=uniqueName');
+    const res = await req(
+      '/items/search/%2FLotus%2FWeapons%2FTenno%2FPistol%2FHandShotGun/?by=uniqueName',
+    );
     res.should.have.status(200);
     res.body.should.be.an('array');
     res.body.length.should.be.greaterThan(0);

--- a/src/spec/items.spec.js
+++ b/src/spec/items.spec.js
@@ -150,13 +150,13 @@ describe('items', () => {
     res.body.length.should.eq(0);
   });
   it('should return an item by a non-default key', async () => {
-    const res = await req('/items/bronco-65d3eb546d.png?by=imageName');
+    const res = await req('/items/%2FLotus%2FWeapons%2FTenno%2FPistol%2FHandShotGun/?by=uniqueName');
     res.should.have.status(200);
     res.body.should.be.an('object');
     Object.keys(res.body).length.should.be.greaterThan(0);
   });
   it('should return multiple items by a non-default key', async () => {
-    const res = await req('/items/search/bronco-65d3eb546d.png?by=imageName');
+    const res = await req('/items/search/%2FLotus%2FWeapons%2FTenno%2FPistol%2FHandShotGun/?by=uniqueName');
     res.should.have.status(200);
     res.body.should.be.an('array');
     res.body.length.should.be.greaterThan(0);


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
This test broke (see #2158) due to a recent image change. To make it more flexible and keep the point of the test it seemed better to look a up a more constant key


---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test cases for the items API to validate querying with different parameter types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->