### PR TITLE
fix: bump `warframe-worldstate-parser`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,6 @@
   "name": "warframe-status",
   "version": "3.2.1",
   "lockfileVersion": 3,
-  "requires": true,
   "packages": {
     "": {
       "name": "warframe-status",
@@ -32,7 +31,7 @@
         "tsx": "^4.22.4",
         "warframe-nexus-query": "^2.3.0",
         "warframe-worldstate-data": "^3.16.1",
-        "warframe-worldstate-parser": "^5.3.9",
+        "warframe-worldstate-parser": "^5.3.13",
         "winston": "^3.19.0",
         "worldstate-emitter": "^2.5.0",
         "ws": "^8.21.0"
@@ -11217,9 +11216,9 @@
       }
     },
     "node_modules/warframe-worldstate-parser": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/warframe-worldstate-parser/-/warframe-worldstate-parser-5.3.9.tgz",
-      "integrity": "sha512-paJ+t5KkWi+DUyFtE1MdEPfswxv6XapDZs40rGkdjY7NCPr6x60zvrdUbcakYU5Gs1gZBNhpfHtwpa35IiE7cA==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/warframe-worldstate-parser/-/warframe-worldstate-parser-5.3.13.tgz",
+      "integrity": "sha512-qAg0eAktjazmgXTq+mtVFXLRkFPM1n0ejLM1BYsNcZO/kOqVVQVI4BPozJzzij6qIWNdy2gZ7bpuGbS/j0gWHg==",
       "license": "MIT",
       "dependencies": {
         "class-transformer": "^0.5.1",
@@ -11746,5 +11745,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     }
-  }
+  },
+  "requires": true
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "tsx": "^4.22.4",
     "warframe-nexus-query": "^2.3.0",
     "warframe-worldstate-data": "^3.16.1",
-    "warframe-worldstate-parser": "^5.3.9",
+    "warframe-worldstate-parser": "^5.3.13",
     "winston": "^3.19.0",
     "worldstate-emitter": "^2.5.0",
     "ws": "^8.21.0"


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Updates the worldstate-parser for duviri choice fix

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **Yes**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to incorporate latest patches and improvements from upstream packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->