### PR TITLE
fix: aggressively hydrate wfinfo data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,6 @@
   "name": "warframe-status",
   "version": "3.2.8",
   "lockfileVersion": 3,
-  "requires": true,
   "packages": {
     "": {
       "name": "warframe-status",
@@ -435,9 +434,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -455,9 +451,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -475,9 +468,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -495,9 +485,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2402,14 +2389,14 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "11.1.27",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.27.tgz",
-      "integrity": "sha512-0ZFhz6H6EdGh4xQVbUNwjoAwBuz73P7FvUAl67h9CTdMqQlJDaQYJApBv8pKfVZ1fGjMCbl0m9DcC6pXaZPWSQ==",
+      "version": "11.1.28",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.28.tgz",
+      "integrity": "sha512-hU+9Sz4m+onHrR5AmelI59QKmY/Re546bPnygnpqqeQdHDiJpBgjWbL4t6Jr73CBpS60cpyng7WzjgphNB9iwA==",
       "license": "MIT",
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
-        "multer": "2.1.1",
+        "multer": "2.2.0",
         "path-to-regexp": "8.4.2",
         "tslib": "2.8.1"
       },
@@ -7063,9 +7050,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
-      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
@@ -9949,5 +9936,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     }
-  }
+  },
+  "requires": true
 }

--- a/src/services/hydration.service.ts
+++ b/src/services/hydration.service.ts
@@ -168,6 +168,17 @@ export class HydrationService implements OnModuleInit, OnApplicationBootstrap {
   }
 
   /**
+   * Check every minute that the wfinfo data exists
+   */
+  @Cron('0 */2 * * * *', {
+    name: 'wfinfo-cache-hydration',
+    timeZone: 'UTC',
+  })
+  async checkWfInfo(): Promise<void> {
+    await this.wfinfoCache.populate();
+  }
+
+  /**
    * Wait for cache-ready signal from primary process
    */
   private async waitForCacheReady(): Promise<void> {

--- a/src/services/hydration.service.ts
+++ b/src/services/hydration.service.ts
@@ -168,13 +168,24 @@ export class HydrationService implements OnModuleInit, OnApplicationBootstrap {
   }
 
   /**
-   * Check every minute that the wfinfo data exists
+   * Check every even minute that the wfinfo data exists
    */
   @Cron('0 */2 * * * *', {
     name: 'wfinfo-cache-hydration',
     timeZone: 'UTC',
   })
   async checkWfInfo(): Promise<void> {
+    const useCluster = USE_CLUSTER;
+    const isPrimary = !useCluster || cluster.isPrimary;
+
+    if (!isPrimary) {
+      this.logger.debug(
+        'Worker: Skipping scheduled hydration (runs on primary only)',
+      );
+      return;
+    }
+
+    this.logger.info('Primary: Scheduled wfinfo cache hydration started');
     await this.wfinfoCache.populate();
   }
 

--- a/src/services/wfinfo-cache.service.ts
+++ b/src/services/wfinfo-cache.service.ts
@@ -81,6 +81,8 @@ export class WFInfoCacheService {
    */
   private async hydrate(): Promise<void> {
     const start = Date.now();
+    let filteredUpdated = false;
+    let pricesUpdated = false;
 
     // Fetch filtered items if URL is configured
     if (this.filteredItemsUrl) {
@@ -92,6 +94,7 @@ export class WFInfoCacheService {
           const data = JSON.parse(itemsRaw);
           if (data && Object.keys(data?.relics ?? {})?.length > 0) {
             await this.cache.set('filteredItems', data);
+            filteredUpdated = true;
           } else {
             this.logger.error(
               `Fetched invalid data from wfinfo filtered items`,
@@ -122,6 +125,7 @@ export class WFInfoCacheService {
           if ((data?.length ?? 0) > 0) {
             // don't allow setting invalid data
             await this.cache.set('prices', data);
+            pricesUpdated = true;
           } else {
             this.logger.error(`Fetched invalid data from wfinfo prices`);
           }
@@ -137,7 +141,9 @@ export class WFInfoCacheService {
 
     if (
       (await this.cache.get('prices')) &&
-      (await this.cache.get('filteredItems'))
+      (await this.cache.get('filteredItems')) &&
+      pricesUpdated &&
+      filteredUpdated
     ) {
       // don't set last update unless both caches are successfully set, forcing hydrate to rerun at the next minute
       this.lastUpdate = Date.now();

--- a/src/services/wfinfo-cache.service.ts
+++ b/src/services/wfinfo-cache.service.ts
@@ -90,7 +90,13 @@ export class WFInfoCacheService {
 
         try {
           const data = JSON.parse(itemsRaw);
-          await this.cache.set('filteredItems', data);
+          if (data && Object.keys(data?.relics ?? {})?.length > 0) {
+            await this.cache.set('filteredItems', data);
+          } else {
+            this.logger.error(
+              `Fetched invalid data from wfinfo filtered items`,
+            );
+          }
         } catch (error) {
           const err = error as Error;
           this.logger.error(
@@ -113,7 +119,12 @@ export class WFInfoCacheService {
 
         try {
           const data = JSON.parse(pricesRaw);
-          await this.cache.set('prices', data);
+          if ((data?.length ?? 0) > 0) {
+            // don't allow setting invalid data
+            await this.cache.set('prices', data);
+          } else {
+            this.logger.error(`Fetched invalid data from wfinfo prices`);
+          }
         } catch (error) {
           const err = error as Error;
           this.logger.error('Failed to update wfinfo Prices', err.stack);
@@ -124,8 +135,14 @@ export class WFInfoCacheService {
       }
     }
 
-    this.lastUpdate = Date.now();
-    await this.setLastUpdate();
+    if (
+      (await this.cache.get('prices')) &&
+      (await this.cache.get('filteredItems'))
+    ) {
+      // don't set last update unless both caches are successfully set, forcing hydrate to rerun at the next minute
+      this.lastUpdate = Date.now();
+      await this.setLastUpdate();
+    }
 
     const end = Date.now();
     this.logger.info(`WFInfo Hydration complete in ${end - start}ms`);


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
work on #2202

---

### Reproduction steps
if the wfinfo info fails to fetch, log more errors & more aggressively try to hydrate every other minute

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Maintenance]**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WFInfo cache data now refreshes automatically every two minutes.

* **Bug Fixes**
  * Invalid or empty cache responses are no longer saved.
  * Cache freshness timestamps are updated only after all required data is successfully populated.
  * Incomplete cache updates automatically trigger another refresh attempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->